### PR TITLE
Provide parser extraction script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,28 @@ If you do not need these packages, set -DOPENBLAS=0 (default);
 otherwise, set -DOPENBLAS=1.
 The default version of OpenBLAS is not very stable for cross platforms, which often results in compiling errors. 
 OpenBLAS is integrated as a submodule which fetch source code from remote repository. 
-If you already have OpenBLAS in the directory, simply run "git submodule update" to fetch the latest version in the submodule directory. 
+If you already have OpenBLAS in the directory, simply run "git submodule update" to fetch the latest version in the submodule directory.
+
+# Extracting Parsers Only
+
+If you only need the parser libraries without the rest of Limbo, a helper
+script is provided. Run
+
+```
+tools/extract_parsers/extract_parsers.sh /path/to/standalone
+```
+
+This copies all parser sources and the minimal headers into the given
+directory and writes a simple `CMakeLists.txt` to build them. Afterwards
+compile the standalone copy with
+
+```
+mkdir build && cd build
+cmake ..
+make
+```
+
+Flex, Bison and Boost must be installed on your system.
 
 # FAQ 
 

--- a/tools/extract_parsers/extract_parsers.sh
+++ b/tools/extract_parsers/extract_parsers.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copy parser sources and minimal dependencies to a standalone directory.
+# Usage: ./extract_parsers.sh <destination_directory>
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <destination_directory>" >&2
+    exit 1
+fi
+
+DEST="$1"
+mkdir -p "$DEST/limbo"
+
+cp -r "$(dirname "$0")"/../../limbo/parsers "$DEST/limbo/"
+cp -r "$(dirname "$0")"/../../limbo/math "$DEST/limbo/"
+cp -r "$(dirname "$0")"/../../limbo/string "$DEST/limbo/"
+cp -r "$(dirname "$0")"/../../limbo/preprocessor "$DEST/limbo/"
+cp -r "$(dirname "$0")"/../../limbo/thirdparty "$DEST/limbo/"
+
+cat > "$DEST/CMakeLists.txt" <<'CMAKE'
+cmake_minimum_required(VERSION 3.7)
+project(LimboParsers)
+set(INSTALL_LIMBO ON CACHE BOOL "")
+add_subdirectory(limbo/math)
+add_subdirectory(limbo/string)
+add_subdirectory(limbo/preprocessor)
+add_subdirectory(limbo/thirdparty)
+add_subdirectory(limbo/parsers)
+CMAKE
+
+echo "Standalone parser sources copied to $DEST"
+


### PR DESCRIPTION
## Summary
- add helper script to copy the parsers folder with its minimal dependencies
- document how to use the script in the README

## Testing
- `bash tools/extract_parsers/extract_parsers.sh /tmp/parsers_test`
